### PR TITLE
Add output command

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@w3f/terraform",
   "version": "0.2.0",
   "description": "Terraform manager",
-  "repository": "git@github.com:w3f/helm-ts.git",
+  "repository": "git@github.com:w3f/terraform-ts.git",
   "author": "W3F Infrastructure Team <devops@web3.foundation>",
   "license": "Apache-2.0",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@w3f/terraform",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Terraform manager",
   "repository": "git@github.com:w3f/helm-ts.git",
   "author": "W3F Infrastructure Team <devops@web3.foundation>",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "start": "node ./dist/index.js start"
   },
   "dependencies": {
-    "@w3f/cmd": "^0.3.0",
+    "@w3f/cmd": "^0.4.0",
     "@w3f/logger": "^0.4.0",
     "fs-extra": "^9.0.0",
     "tmp": "^0.2.1"
@@ -37,7 +37,6 @@
     "@typescript-eslint/parser": "^2.25.0",
     "@w3f/components": "^0.4.0",
     "chai": "^4.2.0",
-    "chai-as-promised": "^7.1.1",
     "eslint": "^6.6.0",
     "mocha": "^7.0.0",
     "ts-node": "^8.6.2",

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,10 @@ export interface TerraformConfig {
     logger: Logger;
 }
 
+export interface ModuleMap {
+    [location: string]: string;
+}
+
 export interface ModuleConfig {
     moduleLocation: string;
     vars?: any;
@@ -17,13 +21,15 @@ export interface TerraformManager {
     apply(moduleCfg: ModuleConfig): Promise<void>;
     destroy(moduleCfg: ModuleConfig): Promise<void>;
     plan(moduleCfg: ModuleConfig): Promise<TerraformPlanRepresentation>;
+    output(moduleCfg: ModuleConfig, name: string): Promise<any>;
 }
 
 export enum TerraformAction {
     Init = 'init',
     Apply = 'apply',
     Destroy = 'destroy',
-    Plan = 'plan'
+    Plan = 'plan',
+    Output = 'output'
 }
 
 export enum TerraformChangeAction {

--- a/test/modules/test/outputs.tf
+++ b/test/modules/test/outputs.tf
@@ -1,0 +1,3 @@
+output "network_data" {
+  value = docker_container.foo.network_data
+}

--- a/test/tf.ts
+++ b/test/tf.ts
@@ -128,8 +128,23 @@ describe('Terraform', () => {
                 await checkDestroy(subject, valuesName);
             });
         });
-    });
+        describe('output', () => {
+            beforeEach(async () => {
+                await checkInstall(subject);
+            });
+            afterEach(async () => {
+                await checkDestroy(subject, valuesName);
+            });
 
+            it('should return an existing output', async () => {
+                const result = await subject.output(moduleCfg, 'network_data');
+                result[0]['network_name'].should.eq('bridge');
+            });
+            it('should throw on unexisting output', async () => {
+                (async () => await subject.output(moduleCfg, 'unexisting')).should.throw;
+            });
+        });
+    });
     describe('static factory', () => {
         before(async () => {
             subjectFromFactory = await Terraform.createBare();

--- a/yarn.lock
+++ b/yarn.lock
@@ -141,10 +141,10 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@w3f/cmd@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@w3f/cmd/-/cmd-0.3.0.tgz#e2e84a8549c6fb11c6b5a3e373cea95ccb064f4e"
-  integrity sha512-TfStpc4L13Pc/rpQ29rv6Nc3BjSZ+S62PUb0VMV3ZCVC7qm8EMMuyQWzxeFW8jPRtfj8mspTdMP4EYRIKnUOWw==
+"@w3f/cmd@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@w3f/cmd/-/cmd-0.4.0.tgz#bb410f8361e9c82b7fcad12c973da13dbaed4dbe"
+  integrity sha512-oAdDjSPEfysfthQEN356JzQDyPLM+fuxthkCeuJiGFPsw+OfVTkfVJK2drsa6kUykBx+MQWaGwvIMMbYlgFC9g==
   dependencies:
     "@w3f/logger" "^0.3.0"
 
@@ -336,13 +336,6 @@ camelcase@^5.0.0:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
-
-chai-as-promised@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
-  integrity sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==
-  dependencies:
-    check-error "^1.0.2"
 
 chai@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
Towards https://github.com/w3f/polkadot-lab/issues/60

Adds an `output` command to the public interface, so that we can get `terraform output` results, required for instance to get the kubeconfig of a cluster used in polkadot-lab.

Additionally, now each terraform command is executed in a separate directory (one for each terraform module), so that the potential state files don't interfere with each other for calls using different modules.